### PR TITLE
Define PATH on nodes

### DIFF
--- a/templates/node.xml.j2
+++ b/templates/node.xml.j2
@@ -29,6 +29,8 @@
           <string>/usr/bin/python2.6</string>
           <string>PYTHON27</string>
           <string>/usr/bin/python2.7</string>
+          <string>PATH</string>
+          <string>$PATH:/home/jenkins/.local/bin</string>
         </tree-map>
       </envVars>
     </hudson.slaves.EnvironmentVariablesNodeProperty>


### PR DESCRIPTION
nodeJS needs to be on the PATH and installed locally,
thus nodes need to know where to find it.

Related to:
https://github.com/plone/plone.jenkins_node/pull/4
https://github.com/plone/jenkins.plone.org/issues/108